### PR TITLE
feat: add --oc flag to write context to README_context.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Find README.md files and analyze them
 - Support `cnav analyze <path>` to analyze a specific path
 - Support project config files for other languages
+- Support `--oc` flag to generate repository context to `README_context.md`
 
 ## [0.1.0] - 2025-04-15
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ cnav last 7d  # shorthand
 # Code review on recent changes
 cnav last --review
 
+# Analyze and generate repository context to README_context.md
+cnav analyze --oc
+
 # Update CHANGELOG file with recent changes
 cnav changelog
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cnav",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Commit Navigator - A CLI tool to understand git commit changes using LLM",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -8,7 +8,7 @@ import { promises as fs } from 'fs';
 export interface AnalyzeCommandOptions {
   review?: boolean;
   md?: boolean;
-  oc?: boolean;
+  outputContext?: boolean;
 }
 
 /**
@@ -44,7 +44,7 @@ export async function analyzeCommand(projectPath: string = '.', options: Analyze
       const projectTree = await getProjectTree();
       
       // Handle --oc flag for context output only
-      if (options.oc) {
+      if (options.outputContext) {
         spinner.text = 'Generating repository context...';
         
         const context = generateRepositoryContext(projectInfo, projectTree, targetPath);

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -8,6 +8,7 @@ import { promises as fs } from 'fs';
 export interface AnalyzeCommandOptions {
   review?: boolean;
   md?: boolean;
+  oc?: boolean;
 }
 
 /**
@@ -41,6 +42,30 @@ export async function analyzeCommand(projectPath: string = '.', options: Analyze
       // Get project information and structure
       const projectInfo = await getProjectInfo();
       const projectTree = await getProjectTree();
+      
+      // Handle --oc flag for context output only
+      if (options.oc) {
+        spinner.text = 'Generating repository context...';
+        
+        const context = generateRepositoryContext(projectInfo, projectTree, targetPath);
+        
+        // Write context to README_context.md
+        const contextPath = path.join(targetPath, 'README_context.md');
+        await fs.writeFile(contextPath, context, 'utf8');
+        
+        spinner.succeed('Repository context generated');
+        console.log(chalk.green(`\n📄 Repository context saved to: ${contextPath}`));
+        
+        if (options.md) {
+          console.log('\n' + chalk.bold.green('📊 Repository Context (Markdown Output)'));
+          console.log(context);
+        } else {
+          console.log('\n' + chalk.bold.green('📊 Repository Context (Plain Text Output)'));
+          console.log(context.replace(/\*\*|\`/g, ''));
+        }
+        
+        return;
+      }
       
       spinner.text = 'Analyzing current project...';
       
@@ -89,6 +114,91 @@ export async function analyzeCommand(projectPath: string = '.', options: Analyze
 }
 
 /**
+ * Generate repository context without analysis instructions
+ */
+function generateRepositoryContext(
+  projectInfo: Record<string, any>,
+  projectTree: string,
+  projectPath: string
+): string {
+  let context = `# Repository Context\n\n`;
+  
+  // Add project information
+  context += `## Project Information\n`;
+  context += `Path: ${projectPath}\n`;
+  
+  // Handle Node.js/JavaScript projects
+  if (projectInfo.packageJson) {
+    context += `Project name: ${projectInfo.packageJson.name || 'Unknown'}\n`;
+    context += `Description: ${projectInfo.packageJson.description || 'N/A'}\n`;
+    context += `Version: ${projectInfo.packageJson.version || 'N/A'}\n`;
+    context += `Dependencies: ${Object.keys(projectInfo.packageJson.dependencies || {}).join(', ') || 'None'}\n`;
+    context += `Dev Dependencies: ${Object.keys(projectInfo.packageJson.devDependencies || {}).join(', ') || 'None'}\n`;
+    
+    if (projectInfo.packageJson.scripts) {
+      context += `Scripts: ${Object.keys(projectInfo.packageJson.scripts).join(', ')}\n`;
+    }
+  }
+  
+  // Handle configuration files from new structure
+  if (projectInfo.configFiles) {
+    const { configFiles } = projectInfo;
+    
+    // Add technology stack information
+    const technologies = Object.keys(configFiles);
+    if (technologies.length > 0) {
+      context += `Technologies detected: ${technologies.join(', ')}\n`;
+    }
+    
+    // Handle Python projects
+    if (configFiles.python) {
+      if (configFiles.python['pyproject.toml']) {
+        context += `Python project with pyproject.toml configuration\n`;
+      }
+      if (configFiles.python['requirements.txt']) {
+        const requirements = configFiles.python['requirements.txt'].content;
+        const deps = requirements.split('\n').filter((r: string) => r.trim() !== '' && !r.startsWith('#'));
+        context += `Python requirements: ${deps.slice(0, 10).join(', ')}${deps.length > 10 ? ' and more...' : ''}\n`;
+      }
+      if (configFiles.python['Pipfile']) {
+        context += `Python project using Pipenv for dependency management\n`;
+      }
+    }
+    
+    // Handle other technology stacks
+    if (configFiles.docker) {
+      context += `Docker configuration detected\n`;
+    }
+    
+    if (configFiles.cicd) {
+      const cicdFiles = Object.keys(configFiles.cicd);
+      context += `CI/CD configured: ${cicdFiles.join(', ')}\n`;
+    }
+    
+    if (configFiles.linting) {
+      const lintingTools = Object.keys(configFiles.linting);
+      context += `Code quality tools: ${lintingTools.join(', ')}\n`;
+    }
+  }
+  
+  // Add README files for context
+  if (projectInfo.README && Object.keys(projectInfo.README).length > 0) {
+    context += `\n## Project Documentation\n`;
+    Object.entries(projectInfo.README).forEach(([path, content]) => {
+      const truncatedContent = (content as string).length > 3000 
+        ? (content as string).substring(0, 3000) + '...\n[README truncated for brevity]'
+        : content as string;
+      
+      context += `### ${path}\n\`\`\`\n${truncatedContent}\n\`\`\`\n\n`;
+    });
+  }
+  
+  context += `## Project Structure\n\`\`\`\n${projectTree}\`\`\`\n\n`;
+  
+  return context;
+}
+
+/**
  * Create a prompt for analyzing a project directory
  */
 function createProjectAnalysisPrompt(
@@ -117,77 +227,11 @@ function createProjectAnalysisPrompt(
 - Main features and capabilities\n\n`;
   }
   
-  // Add project information
-  prompt += `## Project Information\n`;
-  prompt += `Path: ${projectPath}\n`;
-  
-  // Handle Node.js/JavaScript projects
-  if (projectInfo.packageJson) {
-    prompt += `Project name: ${projectInfo.packageJson.name || 'Unknown'}\n`;
-    prompt += `Description: ${projectInfo.packageJson.description || 'N/A'}\n`;
-    prompt += `Version: ${projectInfo.packageJson.version || 'N/A'}\n`;
-    prompt += `Dependencies: ${Object.keys(projectInfo.packageJson.dependencies || {}).join(', ') || 'None'}\n`;
-    prompt += `Dev Dependencies: ${Object.keys(projectInfo.packageJson.devDependencies || {}).join(', ') || 'None'}\n`;
-    
-    if (projectInfo.packageJson.scripts) {
-      prompt += `Scripts: ${Object.keys(projectInfo.packageJson.scripts).join(', ')}\n`;
-    }
-  }
-  
-  // Handle configuration files from new structure
-  if (projectInfo.configFiles) {
-    const { configFiles } = projectInfo;
-    
-    // Add technology stack information
-    const technologies = Object.keys(configFiles);
-    if (technologies.length > 0) {
-      prompt += `Technologies detected: ${technologies.join(', ')}\n`;
-    }
-    
-    // Handle Python projects
-    if (configFiles.python) {
-      if (configFiles.python['pyproject.toml']) {
-        prompt += `Python project with pyproject.toml configuration\n`;
-      }
-      if (configFiles.python['requirements.txt']) {
-        const requirements = configFiles.python['requirements.txt'].content;
-        const deps = requirements.split('\n').filter((r: string) => r.trim() !== '' && !r.startsWith('#'));
-        prompt += `Python requirements: ${deps.slice(0, 10).join(', ')}${deps.length > 10 ? ' and more...' : ''}\n`;
-      }
-      if (configFiles.python['Pipfile']) {
-        prompt += `Python project using Pipenv for dependency management\n`;
-      }
-    }
-    
-    // Handle other technology stacks
-    if (configFiles.docker) {
-      prompt += `Docker configuration detected\n`;
-    }
-    
-    if (configFiles.cicd) {
-      const cicdFiles = Object.keys(configFiles.cicd);
-      prompt += `CI/CD configured: ${cicdFiles.join(', ')}\n`;
-    }
-    
-    if (configFiles.linting) {
-      const lintingTools = Object.keys(configFiles.linting);
-      prompt += `Code quality tools: ${lintingTools.join(', ')}\n`;
-    }
-  }
-  
-  // Add README files for context
-  if (projectInfo.README && Object.keys(projectInfo.README).length > 0) {
-    prompt += `\n## Project Documentation\n`;
-    Object.entries(projectInfo.README).forEach(([path, content]) => {
-      const truncatedContent = (content as string).length > 3000 
-        ? (content as string).substring(0, 3000) + '...\n[README truncated for brevity]'
-        : content as string;
-      
-      prompt += `### ${path}\n\`\`\`\n${truncatedContent}\n\`\`\`\n\n`;
-    });
-  }
-  
-  prompt += `## Project Structure\n\`\`\`\n${projectTree}\`\`\`\n\n`;
+  // Reuse the repository context generation
+  const repositoryContext = generateRepositoryContext(projectInfo, projectTree, projectPath);
+  // Remove the "# Repository Context" header and add the content
+  const contextContent = repositoryContext.replace(/^# Repository Context\n\n/, '');
+  prompt += contextContent;
   
   // Add specific instructions based on analysis type
   if (options.review) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ program
 program.addHelpText('after', `
 Examples:
   cnav                    - analyze current project directory
+  cnav --oc               - generate repository context to README_context.md
   cnav 2                  - analyze the last 2 commits
   cnav 3d                 - analyze commits in the last 3 days
   cnav analyze --oc       - analyze and generate repository context to README_context.md
@@ -58,7 +59,7 @@ const hasOcFlag = args.includes('--oc') || args.includes('--output-context');
 
 // If no arguments provided, or only --oc flag, run analyze command on current directory
 if (!args.length || (hasOcFlag && args.length <= 1)) {
-  analyzeCommand('.', { oc: hasOcFlag });
+  analyzeCommand('.', { outputContext: hasOcFlag });
 } 
 // If single argument that's not a flag or known command, treat as path to analyze
 else if (args.length === 1 && !args[0].startsWith('-') && !['last', 'changelog', 'analyze', 'help', '--help', '-h', '--version', '-V'].includes(args[0])) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@ console.log(chalk.bold.blue('🧭 Commit Navigator (cnav)'));
 program
   .name('cnav')
   .description('Commit Navigator - A CLI tool to understand git commit changes using LLM')
-  .version(VERSION);
+  .version(VERSION)
+  .option('--oc, --output-context', 'Write repository context to README_context.md');
 
 // Command: cnav analyze [path]
 program
@@ -22,6 +23,7 @@ program
   .description('Analyze a project directory (defaults to current directory)')
   .option('-r, --review', 'Perform a detailed code review of the project')
   .option('-m, --md', 'Output analysis in Markdown format')
+  .option('--oc, --output-context', 'Write repository context to README_context.md')
   .action(analyzeCommand);
   
 // Command: cnav last [n]
@@ -51,9 +53,12 @@ Examples:
 // Handle custom logic before parsing
 const args = process.argv.slice(2);
 
-// If no arguments provided, run analyze command on current directory
-if (!args.length) {
-  analyzeCommand('.', {});
+// Check if --oc flag is present
+const hasOcFlag = args.includes('--oc') || args.includes('--output-context');
+
+// If no arguments provided, or only --oc flag, run analyze command on current directory
+if (!args.length || (hasOcFlag && args.length <= 1)) {
+  analyzeCommand('.', { oc: hasOcFlag });
 } 
 // If single argument that's not a flag or known command, treat as path to analyze
 else if (args.length === 1 && !args[0].startsWith('-') && !['last', 'changelog', 'analyze', 'help', '--help', '-h', '--version', '-V'].includes(args[0])) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ program
   .name('cnav')
   .description('Commit Navigator - A CLI tool to understand git commit changes using LLM')
   .version(VERSION)
-  .option('--oc, --output-context', 'Write repository context to README_context.md');
 
 // Command: cnav analyze [path]
 program
@@ -48,6 +47,7 @@ Examples:
   cnav                    - analyze current project directory
   cnav 2                  - analyze the last 2 commits
   cnav 3d                 - analyze commits in the last 3 days
+  cnav analyze --oc       - analyze and generate repository context to README_context.md
 `);
 
 // Handle custom logic before parsing


### PR DESCRIPTION
## Summary by Sourcery

Add an output-context (--oc) flag to the analyze command that generates and writes repository context to README_context.md, refactoring prompt functions to separate context generation, updating the CLI to support the new flag and bumping the package version.

New Features:
- Add an --oc (--output-context) flag to write repository context to README_context.md
- Support optional Markdown or plain-text console output when using the --oc flag
- Provide a new generateRepositoryContext function for context-only extraction

Enhancements:
- Refactor createProjectAnalysisPrompt to reuse the extracted repository context
- Update CLI argument handling to run analyzeCommand by default when no other commands or only --oc is provided

Build:
- Bump package version to 0.2.1

Documentation:
- Update CHANGELOG.md with the new --oc flag entry